### PR TITLE
Potetinal fix for incorrect phpunit stats

### DIFF
--- a/src/CoverageCheck.php
+++ b/src/CoverageCheck.php
@@ -135,7 +135,13 @@ class CoverageCheck
     protected function matchLines($fileName, $matchedFile)
     {
         foreach ($this->cache->diff[$fileName] as $line) {
-            if ($this->fileChecker->isValidLine($matchedFile, $line)) {
+            $validLine = $this->fileChecker->isValidLine($matchedFile, $line);
+
+            if (is_null($validLine)) {
+                continue;
+            }
+
+            if ($validLine) {
                 $this->addCoveredLine($fileName, $line);
                 continue;
             }

--- a/src/FileChecker.php
+++ b/src/FileChecker.php
@@ -14,9 +14,10 @@ interface FileChecker
 
     /**
      * Method to determine if the line is valid in the context
+     * null does not include the line in the stats
      * @param $file
      * @param $lineNumber
-     * @return bool
+     * @return bool|null
      */
     public function isValidLine($file, $lineNumber);
 

--- a/src/XMLReport.php
+++ b/src/XMLReport.php
@@ -65,9 +65,11 @@ class XMLReport implements FileChecker
      */
     public function isValidLine($file, $line)
     {
-        return
-            !isset($this->coveredLines[$file][$line]) ||
-            $this->coveredLines[$file][$line] > 0;
+        if (!isset($this->coveredLines[$file][$line])) {
+            return;
+        }
+
+        return $this->coveredLines[$file][$line] > 0;
     }
 
     /**

--- a/tests/CoverageCheckTest.php
+++ b/tests/CoverageCheckTest.php
@@ -232,4 +232,55 @@ class CoverageCheckTest extends TestCase
 
         $this->assertEquals($expected, $lines);
     }
+
+    public function testCoverageForContextLines()
+    {
+        $diffFileState = $this->createMock(DiffFileLoader::class);
+        $diffFileState->method('getChangedLines')
+            ->willReturn([
+                'testFile1.php' => [1,2,4],
+
+            ]);
+
+        $xmlReport = $this->createMock(XMLReport::class);
+        $xmlReport->method('getLines')
+            ->willReturn([
+                '/full/path/to/testFile1.php' => [1 => 1,4 => 1],
+
+            ]);
+
+        $xmlReport->method('handleNotFoundFile')
+            ->willReturn(false);
+
+        $xmlReport->method('isValidLine')
+            ->will(
+                $this->returnCallback(
+                    function () {
+                        $file = func_get_arg(0);
+                        $line = func_get_arg(1);
+
+                        if ($file == '/full/path/to/testFile1.php' && $line == 2) {
+                            return null;
+                        }
+
+                        return true;
+                    }
+                )
+            );
+
+        $matcher = new FileMatchers\EndsWith;
+        $coverageCheck = new CoverageCheck($diffFileState, $xmlReport, $matcher);
+        $lines = $coverageCheck->getCoveredLines();
+
+        $coveredLines = [
+            'testFile1.php' => [1,4],
+        ];
+
+        $expected = [
+            'coveredLines' => $coveredLines,
+            'uncoveredLines' => [],
+        ];
+
+        $this->assertEquals($expected, $lines);
+    }
 }

--- a/tests/LoadXMLReportTest.php
+++ b/tests/LoadXMLReportTest.php
@@ -30,7 +30,7 @@ class LoadXMLReportTest extends TestCase
         $this->assertFalse($xmlReport->isValidLine('/path/to/file/changedFile.php', 14));
         $this->assertTrue($xmlReport->isValidLine('/path/to/file/changedFile.php', 10));
         //True as the report doesnt contain the file
-        $this->assertTrue($xmlReport->isValidLine('/path/to/file/NonExistantFile.php', 6));
+        $this->assertNull($xmlReport->isValidLine('/path/to/file/NonExistantFile.php', 6));
     }
 
     public function testCorrectMissingFile()

--- a/tests/PhpunitDiffFilterTest.php
+++ b/tests/PhpunitDiffFilterTest.php
@@ -26,7 +26,7 @@ class PhpunitDiffFilterTest extends TestCase
         ob_start();
         require(__DIR__ . "/../src/runners/phpunitDiffFilter.php");
         $output = ob_get_clean();
-        $this->assertContains('100.00%', $output);
+        $this->assertContains('No lines found', $output);
     }
 
     public function testFailingBuild()

--- a/tests/fixtures/coverage-change.xml
+++ b/tests/fixtures/coverage-change.xml
@@ -3,6 +3,8 @@
   <project timestamp="123456">
     <package name="ns\packageName">
       <file name="/path/to/file/changedFile.php">
+        <line num="1" type="stmt" count="1"/>
+        <line num="2" type="stmt" count="1"/>
         <line num="3" type="stmt" count="0"/>
         <line num="10" type="stmt" count="4"/>
         <line num="11" type="stmt" count="4"/>


### PR DESCRIPTION
Some of the context lines (ie not stmt lines) were being included in the
count. Therefore the text coverage was inflated