### PR TITLE
Use the longest string for the haystack in phpmnd

### DIFF
--- a/src/FileMatchers/EndsWith.php
+++ b/src/FileMatchers/EndsWith.php
@@ -34,6 +34,9 @@ class EndsWith implements FileMatcher
     protected function fileEndsWith($haystack, $needle)
     {
         $length = strlen($needle);
+        if (strlen($haystack) < $length) {
+            return $this->fileEndsWith($needle, $haystack);
+        }
 
         return (substr($haystack, -$length) === $needle);
     }

--- a/tests/PhpMndTest.php
+++ b/tests/PhpMndTest.php
@@ -8,7 +8,7 @@ class PhpMndTest extends TestCase
 {
     public function setUp()
     {
-        $file = __DIR__ . "/fixtures/phpmnd.txt";
+            $file = __DIR__ . "/fixtures/phpmnd.txt";
         $this->mnd = new PhpMndLoader($file);
 
         $this->assertInstanceOf(PhpMndLoader::class, $this->mnd);


### PR DESCRIPTION
phpmnd does not show the full path so every check passed, This uses the longest string to compare to