### PR TITLE
Explicit requiring php 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "bin": ["bin/phpunitDiffFilter","bin/phpcsDiffFilter", "bin/phpmdDiffFilter", "bin/diffFilter"],
     "require": {
+        "php": ">=5.5",
         "nikic/php-parser": "^3.1"
     }
 }


### PR DESCRIPTION
Since this lib requires `nikic/php-parser@^3.1`, it also requires `php@>=5.5`