### PR TITLE
Compare file paths with same separators

### DIFF
--- a/src/FileMatchers/EndsWith.php
+++ b/src/FileMatchers/EndsWith.php
@@ -35,6 +35,9 @@ class EndsWith implements FileMatcher
             return $this->fileEndsWith($needle, $haystack);
         }
 
+        $haystack = str_replace('\\', '/', $haystack);
+        $needle = str_replace('\\', '/', $needle);
+        
         return (substr($haystack, -$length) === $needle);
     }
 }


### PR DESCRIPTION
Transform both file paths to have similar path delimiters before comparing them.
Proposed solution to issue #54