### PR TITLE
Consider no lines a valid input,

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -92,6 +92,12 @@ function handleOutput(array $lines, float $minimumPercentCovered, Output $output
 
     if ($coveredLines + $uncoveredLines == 0) {
         error_log('No lines found!');
+        
+        $output->output(
+            $lines['uncoveredLines'],
+            100,
+            $minimumPercentCovered
+        );
         return;
     }
 


### PR DESCRIPTION
and output a valid result.

Fixes https://github.com/exussum12/coverageChecker/issues/72

This is one way to address the above issue.
We can assume that if no lines were changed, therefore there are no PHPCS errors or warnings there, so we can return a output result.