### PR TITLE
Return error exit code for "No lines…" error.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.4/phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         backupGlobals="false"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
-    <testsuite name="coverageChecker">
-        <directory suffix="Test.php">tests</directory>
-    </testsuite>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log
-            type="coverage-html"
-            target="report"
-            lowUpperBound="90"
-            highLowerBound="95"/>
-        <log type="coverage-clover" target="report/coverage.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" backupGlobals="false" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <report>
+      <clover outputFile="report/coverage.xml"/>
+      <html outputDirectory="report" lowUpperBound="90" highLowerBound="95"/>
+    </report>
+  </coverage>
+  <testsuite name="coverageChecker">
+    <directory suffix="Test.php">tests</directory>
+  </testsuite>
+  <logging/>
 </phpunit>

--- a/src/functions.php
+++ b/src/functions.php
@@ -100,7 +100,7 @@ function handleOutput(array $lines, float $minimumPercentCovered, Output $output
         throw new Exception(
             'No lines found!',
             3
-        ); 
+        );
     }
 
     $percentCovered = 100 * ($coveredLines / ($coveredLines + $uncoveredLines));

--- a/src/functions.php
+++ b/src/functions.php
@@ -91,8 +91,10 @@ function handleOutput(array $lines, float $minimumPercentCovered, Output $output
 
 
     if ($coveredLines + $uncoveredLines == 0) {
-        error_log('No lines found!');
-        return;
+        throw new Exception(
+            'No lines found!',
+            3
+        );
     }
 
     $percentCovered = 100 * ($coveredLines / ($coveredLines + $uncoveredLines));

--- a/src/functions.php
+++ b/src/functions.php
@@ -91,7 +91,6 @@ function handleOutput(array $lines, float $minimumPercentCovered, Output $output
 
 
     if ($coveredLines + $uncoveredLines == 0) {
-
         $output->output(
             $lines['uncoveredLines'],
             100,
@@ -101,8 +100,7 @@ function handleOutput(array $lines, float $minimumPercentCovered, Output $output
         throw new Exception(
             'No lines found!',
             3
-        );
-        
+        ); 
     }
 
     $percentCovered = 100 * ($coveredLines / ($coveredLines + $uncoveredLines));

--- a/tests/PhpunitDiffFilterTest.php
+++ b/tests/PhpunitDiffFilterTest.php
@@ -20,7 +20,7 @@ class PhpunitDiffFilterTest extends TestCase
         require(__DIR__ . "/../src/Runners/generic.php");
     }
 
-    public function testWorkingCorrectly()
+    public function testInvalidFileReturnsNoLinesFound()
     {
         $GLOBALS['argv'] = [
             'diffFilter',
@@ -28,10 +28,16 @@ class PhpunitDiffFilterTest extends TestCase
             __DIR__ . '/fixtures/change.txt',
             __DIR__ . '/fixtures/coverage.xml'
         ];
-        ob_start();
-        require(__DIR__ . "/../src/Runners/generic.php");
-        $output = ob_get_clean();
-        $this->assertContainsString('No lines found', $output);
+
+        try {
+            ob_start();
+            require(__DIR__ . "/../src/Runners/generic.php");
+        } catch (Exception $e) {
+            ob_end_clean();
+            $this->assertContainsString('No lines found', $e->getMessage());
+            return;
+        }
+        $this->fail("No Exception thrown");
     }
 
     public function testFailingBuild()
@@ -88,7 +94,7 @@ class PhpunitDiffFilterTest extends TestCase
             ob_start();
             require(__DIR__ . '/../src/Runners/generic.php');
         } catch (Exception $e) {
-            ob_clean();
+            ob_end_clean();
             $this->assertEquals(3, $e->getCode());
             return;
         }

--- a/tests/PhpunitDiffFilterTest.php
+++ b/tests/PhpunitDiffFilterTest.php
@@ -83,9 +83,16 @@ class PhpunitDiffFilterTest extends TestCase
             __DIR__ . '/fixtures/coverage-change.xml',
         ];
 
-        ob_start();
-        require(__DIR__ . '/../src/Runners/generic.php');
-        $output = ob_get_clean();
-        $this->assertContainsString('No lines found', $output);
+
+        try {
+            ob_start();
+            require(__DIR__ . '/../src/Runners/generic.php');
+        } catch (Exception $e) {
+            $output = ob_get_clean();
+            $this->assertEquals(3, $e->getCode());
+            return;
+        }
+
+        $this->fail("no exception thrown");
     }
 }

--- a/tests/PhpunitDiffFilterTest.php
+++ b/tests/PhpunitDiffFilterTest.php
@@ -88,7 +88,7 @@ class PhpunitDiffFilterTest extends TestCase
             ob_start();
             require(__DIR__ . '/../src/Runners/generic.php');
         } catch (Exception $e) {
-            $output = ob_get_clean();
+            ob_clean();
             $this->assertEquals(3, $e->getCode());
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/exussum12/coverageChecker/issues/72

This is one way to address the above issue.
If "no lines" is considered an error, which makes it impossible to produce a meaningful result, we should return an error code.
That way this error is catchable by external users.