### PR TITLE
Fixes typo in git hook scripts

### DIFF
--- a/GitHooks/pre-commit
+++ b/GitHooks/pre-commit
@@ -13,5 +13,5 @@ git diff --cached > ${diff}
 phpcs=$(mktemp)
 ./vendor/bin/phpcs --file-list=${files} --parallel=2 --standard=psr2 --report=json > ${phpcs} || true
 
-check for differences
+# check for differences
 ./vendor/bin/diffFilter --phpcs ${diff} ${phpcs}

--- a/GitHooks/pre-receive
+++ b/GitHooks/pre-receive
@@ -13,5 +13,5 @@ git diff $1...$2 > ${diff}
 phpcs=$(mktemp)
 ./vendor/bin/phpcs --file-list=${files} --parallel=2 --standard=psr2 --report=json > ${phpcs} || true
 
-check for differences
+# check for differences
 ./vendor/bin/diffFilter --phpcs ${diff} ${phpcs}


### PR DESCRIPTION
The Git hooks example scripts fail due to a missing octothorp to denote a comment.